### PR TITLE
[FIXED JENKINS-22532] using rootURL in jelly configuration pages

### DIFF
--- a/src/main/resources/com/sonyericsson/hudson/plugins/metadata/model/definitions/DateMetadataDefinition/config.jelly
+++ b/src/main/resources/com/sonyericsson/hudson/plugins/metadata/model/definitions/DateMetadataDefinition/config.jelly
@@ -30,7 +30,7 @@
                 <td width="80">${%Name}</td>
                 <td colspan="5">
                     <f:textbox name="name" value="${instance.name}"
-                               checkUrl="'/MetadataChecks/checkName?value='+escape(this.value)"/>
+                               checkUrl="'${rootURL}/MetadataChecks/checkName?value='+escape(this.value)"/>
                 </td>
             </tr>
             <!--used to display the form validation error -->
@@ -42,7 +42,7 @@
                 </td>
                 <td width="40">
                     <f:textbox name="year" value="${instance.year}"
-                               checkUrl="'/MetadataChecks/checkDateValue?yearValue='+escape(Form.findMatchingInput(this,'year').value)
+                               checkUrl="'${rootURL}/MetadataChecks/checkDateValue?yearValue='+escape(Form.findMatchingInput(this,'year').value)
                                +'&amp;monthValue='+escape(Form.findMatchingInput(this,'month').value)
                                +'&amp;dayValue='+escape(Form.findMatchingInput(this,'day').value)"/>
                 </td>
@@ -53,7 +53,7 @@
                 </td>
                 <td width="40">
                     <f:textbox name="month" value="${instance.month}"
-                               checkUrl="'/MetadataChecks/checkDateValue?yearValue='+escape(Form.findMatchingInput(this,'year').value)
+                               checkUrl="'${rootURL}/MetadataChecks/checkDateValue?yearValue='+escape(Form.findMatchingInput(this,'year').value)
                                +'&amp;monthValue='+escape(Form.findMatchingInput(this,'month').value)
                                +'&amp;dayValue='+escape(Form.findMatchingInput(this,'day').value)"/>
                 </td>
@@ -63,7 +63,7 @@
                 </td>
                 <td width="40">
                     <f:textbox name="day" value="${instance.day}"
-                               checkUrl="'/MetadataChecks/checkDateValue?yearValue='+escape(Form.findMatchingInput(this,'year').value)
+                               checkUrl="'${rootURL}/MetadataChecks/checkDateValue?yearValue='+escape(Form.findMatchingInput(this,'year').value)
                                +'&amp;monthValue='+escape(Form.findMatchingInput(this,'month').value)
                                +'&amp;dayValue='+escape(Form.findMatchingInput(this,'day').value)"/>
                 </td>
@@ -84,7 +84,7 @@
                     </td>
                     <td width="40">
                         <f:textbox name="hour" value="${instance.hour}"
-                                   checkUrl="'/MetadataChecks/checkTimeValue?hourValue='+escape(Form.findMatchingInput(this,'hour').value)
+                                   checkUrl="'${rootURL}/MetadataChecks/checkTimeValue?hourValue='+escape(Form.findMatchingInput(this,'hour').value)
                                        +'&amp;minuteValue='+escape(Form.findMatchingInput(this,'minute').value)
                                        +'&amp;secondValue='+escape(Form.findMatchingInput(this,'second').value)"/>
                     </td>
@@ -94,7 +94,7 @@
                     </td>
                     <td width="40">
                         <f:textbox name="minute" value="${instance.minute}"
-                                   checkUrl="'/MetadataChecks/checkTimeValue?hourValue='+escape(Form.findMatchingInput(this,'hour').value)
+                                   checkUrl="'${rootURL}/MetadataChecks/checkTimeValue?hourValue='+escape(Form.findMatchingInput(this,'hour').value)
                                        +'&amp;minuteValue='+escape(Form.findMatchingInput(this,'minute').value)
                                        +'&amp;secondValue='+escape(Form.findMatchingInput(this,'second').value)"/>
                     </td>
@@ -104,7 +104,7 @@
                     </td>
                     <td width="40">
                         <f:textbox name="second" value="${instance.second}"
-                                   checkUrl="'/MetadataChecks/checkTimeValue?hourValue='+escape(Form.findMatchingInput(this,'hour').value)
+                                   checkUrl="'${rootURL}/MetadataChecks/checkTimeValue?hourValue='+escape(Form.findMatchingInput(this,'hour').value)
                                        +'&amp;minuteValue='+escape(Form.findMatchingInput(this,'minute').value)
                                        +'&amp;secondValue='+escape(Form.findMatchingInput(this,'second').value)"/>
                     </td>

--- a/src/main/resources/com/sonyericsson/hudson/plugins/metadata/model/definitions/DateMetadataDefinition/representation.jelly
+++ b/src/main/resources/com/sonyericsson/hudson/plugins/metadata/model/definitions/DateMetadataDefinition/representation.jelly
@@ -42,7 +42,7 @@
                 </td>
                 <td width="40">
                     <f:textbox name="year" value="${value.getYear()}"
-                               checkUrl="'/MetadataChecks/checkDateValue?yearValue='+escape(Form.findMatchingInput(this,'year').value)
+                               checkUrl="'${rootURL}/MetadataChecks/checkDateValue?yearValue='+escape(Form.findMatchingInput(this,'year').value)
                                +'&amp;monthValue='+escape(Form.findMatchingInput(this,'month').value)
                                +'&amp;dayValue='+escape(Form.findMatchingInput(this,'day').value)"/>
                 </td>
@@ -53,7 +53,7 @@
                 </td>
                 <td width="40">
                     <f:textbox name="month" value="${value.getMonth()}"
-                               checkUrl="'/MetadataChecks/checkDateValue?yearValue='+escape(Form.findMatchingInput(this,'year').value)
+                               checkUrl="'${rootURL}/MetadataChecks/checkDateValue?yearValue='+escape(Form.findMatchingInput(this,'year').value)
                                +'&amp;monthValue='+escape(Form.findMatchingInput(this,'month').value)
                                +'&amp;dayValue='+escape(Form.findMatchingInput(this,'day').value)"/>
                 </td>
@@ -63,7 +63,7 @@
                 </td>
                 <td width="40">
                     <f:textbox name="day" value="${value.getDay()}"
-                               checkUrl="'/MetadataChecks/checkDateValue?yearValue='+escape(Form.findMatchingInput(this,'year').value)
+                               checkUrl="'${rootURL}/MetadataChecks/checkDateValue?yearValue='+escape(Form.findMatchingInput(this,'year').value)
                                +'&amp;monthValue='+escape(Form.findMatchingInput(this,'month').value)
                                +'&amp;dayValue='+escape(Form.findMatchingInput(this,'day').value)"/>
                 </td>
@@ -85,7 +85,7 @@
                                         </td>
                                         <td width="40">
                                             <f:textbox name="hour" value="${value.getHour()}"
-                                                       checkUrl="'/MetadataChecks/checkTimeValue?hourValue='+escape(Form.findMatchingInput(this,'hour').value)
+                                                       checkUrl="'${rootURL}/MetadataChecks/checkTimeValue?hourValue='+escape(Form.findMatchingInput(this,'hour').value)
                                        +'&amp;minuteValue='+escape(Form.findMatchingInput(this,'minute').value)
                                        +'&amp;secondValue='+escape(Form.findMatchingInput(this,'second').value)"/>
                                         </td>
@@ -95,7 +95,7 @@
                                         </td>
                                         <td width="40">
                                             <f:textbox name="minute" value="${value.getMinute()}"
-                                                       checkUrl="'/MetadataChecks/checkTimeValue?hourValue='+escape(Form.findMatchingInput(this,'hour').value)
+                                                       checkUrl="'${rootURL}/MetadataChecks/checkTimeValue?hourValue='+escape(Form.findMatchingInput(this,'hour').value)
                                        +'&amp;minuteValue='+escape(Form.findMatchingInput(this,'minute').value)
                                        +'&amp;secondValue='+escape(Form.findMatchingInput(this,'second').value)"/>
                                         </td>
@@ -105,7 +105,7 @@
                                         </td>
                                         <td width="40">
                                             <f:textbox name="second" value="${value.getSecond()}"
-                                                       checkUrl="'/MetadataChecks/checkTimeValue?hourValue='+escape(Form.findMatchingInput(this,'hour').value)
+                                                       checkUrl="'${rootURL}/MetadataChecks/checkTimeValue?hourValue='+escape(Form.findMatchingInput(this,'hour').value)
                                        +'&amp;minuteValue='+escape(Form.findMatchingInput(this,'minute').value)
                                        +'&amp;secondValue='+escape(Form.findMatchingInput(this,'second').value)"/>
                                         </td>

--- a/src/main/resources/com/sonyericsson/hudson/plugins/metadata/model/definitions/NumberMetadataDefinition/config.jelly
+++ b/src/main/resources/com/sonyericsson/hudson/plugins/metadata/model/definitions/NumberMetadataDefinition/config.jelly
@@ -26,11 +26,11 @@
 <j:jelly xmlns:j="jelly:core"  xmlns:f="/lib/form">
     <f:entry title="${%Name}">
         <f:textbox name="name" value="${instance.name}"
-        checkUrl="'/MetadataChecks/checkName?value='+escape(this.value)"/>
+        checkUrl="'${rootURL}/MetadataChecks/checkName?value='+escape(this.value)"/>
     </f:entry>
     <f:entry title="${%Default Value}" help="/plugin/metadata/help/definitions/defaultvalue.html">
         <f:textbox name="defaultValue" value="${instance.defaultValue}"
-                   checkUrl="'/MetadataChecks/checkNumberValue?value='+escape(this.value)"/>
+                   checkUrl="'${rootURL}/MetadataChecks/checkNumberValue?value='+escape(this.value)"/>
     </f:entry>
     <f:entry title="${%Description}" help="/plugin/metadata/help/definitions/description.html">
         <f:textarea name="description" value="${instance.description}"/>

--- a/src/main/resources/com/sonyericsson/hudson/plugins/metadata/model/definitions/NumberMetadataDefinition/representation.jelly
+++ b/src/main/resources/com/sonyericsson/hudson/plugins/metadata/model/definitions/NumberMetadataDefinition/representation.jelly
@@ -26,7 +26,7 @@
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
     <f:entry title="${it.fullName}" description="${it.description}">
         <f:textbox value="${value.getValue()}" field="${it.getFullName('_')}"
-                checkUrl="'/MetadataChecks/checkNumberValue?value='+escape(this.value)"/>
+                checkUrl="'${rootURL}/MetadataChecks/checkNumberValue?value='+escape(this.value)"/>
     </f:entry>
 </j:jelly>
 

--- a/src/main/resources/com/sonyericsson/hudson/plugins/metadata/model/definitions/StringMetadataDefinition/config.jelly
+++ b/src/main/resources/com/sonyericsson/hudson/plugins/metadata/model/definitions/StringMetadataDefinition/config.jelly
@@ -26,7 +26,7 @@
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
     <f:entry title="${%Name}">
         <f:textbox name="name" value="${instance.name}"
-                   checkUrl="'/MetadataChecks/checkName?value='+escape(this.value)"/>
+                   checkUrl="'${rootURL}/MetadataChecks/checkName?value='+escape(this.value)"/>
     </f:entry>
     <f:entry title="${%Default Value}" help="/plugin/metadata/help/definitions/defaultvalue.html">
         <f:textbox name="defaultValue" value="${instance.defaultValue}"/>

--- a/src/main/resources/com/sonyericsson/hudson/plugins/metadata/model/definitions/TreeNodeMetadataDefinition/config.jelly
+++ b/src/main/resources/com/sonyericsson/hudson/plugins/metadata/model/definitions/TreeNodeMetadataDefinition/config.jelly
@@ -26,7 +26,7 @@
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
     <f:entry title="${%Name}">
         <f:textbox name="name" value="${instance.name}"
-                   checkUrl="'/MetadataChecks/checkName?value='+escape(this.value)"/>
+                   checkUrl="'${rootURL}/MetadataChecks/checkName?value='+escape(this.value)"/>
     </f:entry>
     <f:entry title="${%Definitions}">
         <f:hetero-list descriptors="${descriptor.getDefinitionDescriptors(request)}" items="${instance.children}"

--- a/src/main/resources/com/sonyericsson/hudson/plugins/metadata/model/values/DateMetadataValue/config.jelly
+++ b/src/main/resources/com/sonyericsson/hudson/plugins/metadata/model/values/DateMetadataValue/config.jelly
@@ -30,7 +30,7 @@
                 <td width="40">${%Name}</td>
                 <td colspan="5">
                     <f:textbox name="name" value="${instance.name}"
-                               checkUrl="'/MetadataChecks/checkName?value='+escape(this.value)"/>
+                               checkUrl="'${rootURL}/MetadataChecks/checkName?value='+escape(this.value)"/>
                 </td>
             </tr>
             <!--used to display the form validation error -->
@@ -42,7 +42,7 @@
                 </td>
                 <td width="40">
                     <f:textbox name="year" value="${instance.year}"
-                               checkUrl="'/MetadataChecks/checkDateValue?yearValue='+escape(Form.findMatchingInput(this,'year').value)
+                               checkUrl="'${rootURL}/MetadataChecks/checkDateValue?yearValue='+escape(Form.findMatchingInput(this,'year').value)
                                +'&amp;monthValue='+escape(Form.findMatchingInput(this,'month').value)
                                +'&amp;dayValue='+escape(Form.findMatchingInput(this,'day').value)"/>
                 </td>
@@ -53,7 +53,7 @@
                 </td>
                 <td width="40">
                     <f:textbox name="month" value="${instance.month}"
-                               checkUrl="'/MetadataChecks/checkDateValue?yearValue='+escape(Form.findMatchingInput(this,'year').value)
+                               checkUrl="'${rootURL}/MetadataChecks/checkDateValue?yearValue='+escape(Form.findMatchingInput(this,'year').value)
                                +'&amp;monthValue='+escape(Form.findMatchingInput(this,'month').value)
                                +'&amp;dayValue='+escape(Form.findMatchingInput(this,'day').value)"/>
                 </td>
@@ -63,7 +63,7 @@
                 </td>
                 <td width="40">
                     <f:textbox name="day" value="${instance.day}"
-                               checkUrl="'/MetadataChecks/checkDateValue?yearValue='+escape(Form.findMatchingInput(this,'year').value)
+                               checkUrl="'${rootURL}/MetadataChecks/checkDateValue?yearValue='+escape(Form.findMatchingInput(this,'year').value)
                                +'&amp;monthValue='+escape(Form.findMatchingInput(this,'month').value)
                                +'&amp;dayValue='+escape(Form.findMatchingInput(this,'day').value)"/>
                 </td>
@@ -83,7 +83,7 @@
                     </td>
                     <td width="40">
                         <f:textbox name="hour" value="${instance.hour}"
-                                   checkUrl="'/MetadataChecks/checkTimeValue?hourValue='+escape(Form.findMatchingInput(this,'hour').value)
+                                   checkUrl="'${rootURL}/MetadataChecks/checkTimeValue?hourValue='+escape(Form.findMatchingInput(this,'hour').value)
                                        +'&amp;minuteValue='+escape(Form.findMatchingInput(this,'minute').value)
                                        +'&amp;secondValue='+escape(Form.findMatchingInput(this,'second').value)"/>
                     </td>
@@ -93,7 +93,7 @@
                     </td>
                     <td width="40">
                         <f:textbox name="minute" value="${instance.minute}"
-                                   checkUrl="'/MetadataChecks/checkTimeValue?hourValue='+escape(Form.findMatchingInput(this,'hour').value)
+                                   checkUrl="'${rootURL}/MetadataChecks/checkTimeValue?hourValue='+escape(Form.findMatchingInput(this,'hour').value)
                                        +'&amp;minuteValue='+escape(Form.findMatchingInput(this,'minute').value)
                                        +'&amp;secondValue='+escape(Form.findMatchingInput(this,'second').value)"/>
                     </td>
@@ -103,7 +103,7 @@
                     </td>
                     <td width="40">
                         <f:textbox name="second" value="${instance.second}"
-                                   checkUrl="'/MetadataChecks/checkTimeValue?hourValue='+escape(Form.findMatchingInput(this,'hour').value)
+                                   checkUrl="'${rootURL}/MetadataChecks/checkTimeValue?hourValue='+escape(Form.findMatchingInput(this,'hour').value)
                                        +'&amp;minuteValue='+escape(Form.findMatchingInput(this,'minute').value)
                                        +'&amp;secondValue='+escape(Form.findMatchingInput(this,'second').value)"/>
                     </td>

--- a/src/main/resources/com/sonyericsson/hudson/plugins/metadata/model/values/NumberMetadataValue/config.jelly
+++ b/src/main/resources/com/sonyericsson/hudson/plugins/metadata/model/values/NumberMetadataValue/config.jelly
@@ -27,11 +27,11 @@
     <!--TODO could not get this page to work like string value, with name and value on same line, due to the checkurl-->
     <f:entry title="${%Name}">
         <f:textbox name="name" value="${instance.name}"
-                   checkUrl="'/MetadataChecks/checkName?value='+escape(this.value)"/>
+                   checkUrl="'${rootURL}/MetadataChecks/checkName?value='+escape(this.value)"/>
     </f:entry>
     <f:entry title="${%Value}">
         <f:textbox name="value" value="${instance.value}"
-                   checkUrl="'/MetadataChecks/checkNumberValue?value='+escape(this.value)"/>
+                   checkUrl="'${rootURL}/MetadataChecks/checkNumberValue?value='+escape(this.value)"/>
     </f:entry>
     <f:entry title="${%Expose to environment}" help="/plugin/metadata/help/environment.html">
         <f:checkbox name="exposedToEnvironment" checked="${instance.isExposedToEnvironment()}"/>

--- a/src/main/resources/com/sonyericsson/hudson/plugins/metadata/model/values/StringMetadataValue/config.jelly
+++ b/src/main/resources/com/sonyericsson/hudson/plugins/metadata/model/values/StringMetadataValue/config.jelly
@@ -29,7 +29,7 @@
             <tr>
                 <td>${%Name}</td>
                 <td width="48%"><f:textbox name="name" value="${instance.name}"
-                                           checkUrl="'/MetadataChecks/checkName?value='+escape(this.value)"/></td>
+                                           checkUrl="'${rootURL}/MetadataChecks/checkName?value='+escape(this.value)"/></td>
                 <td><st:nbsp/><st:nbsp/>${%Value}</td>
                 <td width="48%"><f:textbox name="value" value="${instance.value}"/></td>
             </tr>

--- a/src/main/resources/com/sonyericsson/hudson/plugins/metadata/model/values/TreeNodeMetadataValue/config.jelly
+++ b/src/main/resources/com/sonyericsson/hudson/plugins/metadata/model/values/TreeNodeMetadataValue/config.jelly
@@ -26,7 +26,7 @@
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
     <f:entry title="${%Name}">
         <f:textbox name="name" value="${instance.name}"
-                   checkUrl="'/MetadataChecks/checkName?value='+escape(this.value)"/>
+                   checkUrl="'${rootURL}/MetadataChecks/checkName?value='+escape(this.value)"/>
     </f:entry>
     <f:entry title="${%Values}">
         <f:hetero-list descriptors="${descriptor.getValueDescriptors(request)}" items="${instance.children}"


### PR DESCRIPTION
Hi, this pull request uses ${rootURL} to support Jenkins deployed with a context path.

Issue: https://issues.jenkins-ci.org/browse/JENKINS-22532
