### PR TITLE
Replace deprecated 'hamcrest-*' modules with 'hamcrest'

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
         <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest</artifactId>
-            <version>1.3</version>
+            <version>2.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-all</artifactId>
+            <artifactId>hamcrest</artifactId>
             <version>1.3</version>
             <scope>test</scope>
         </dependency>


### PR DESCRIPTION
_🤖 This is an automatic PR for replacing the deprecated 'hamcrest-*' modules with 'hamcrest'._

All deprecated modules' code has been merged into 'hamcrest'.
Consumers of `hamcrest-*` should replace the dependency with `hamcrest`, which is the drop-in module containing the code of the deprecated `hamcrest-*` modules.

Ping `@NotMyFault` if you have questions.

_[script source](https://github.com/NotMyFault/jenkins-version-updater)_
